### PR TITLE
Fix nodes loop for networkx >= 2.4

### DIFF
--- a/src/ibtopotool.py
+++ b/src/ibtopotool.py
@@ -173,7 +173,6 @@ def treeify(g, rootfile):
 
 def only_switches(g):
     """Filter out nodes that are not switches"""
-    # print(g.nodes()['S-248a070300f7aff0'])
     return g.subgraph([n for n in g.nodes() if g.nodes()[n]['type']
                        == 'Switch'])
 

--- a/src/ibtopotool.py
+++ b/src/ibtopotool.py
@@ -173,7 +173,8 @@ def treeify(g, rootfile):
 
 def only_switches(g):
     """Filter out nodes that are not switches"""
-    return g.subgraph([n for n, attrs in g.node.items() if attrs['type']
+    # print(g.nodes()['S-248a070300f7aff0'])
+    return g.subgraph([n for n in g.nodes() if g.nodes()[n]['type']
                        == 'Switch'])
 
 def relabel_switch_tree(g):

--- a/src/ibtopotool.py
+++ b/src/ibtopotool.py
@@ -173,7 +173,7 @@ def treeify(g, rootfile):
 
 def only_switches(g):
     """Filter out nodes that are not switches"""
-    return g.subgraph([n for n in g.nodes() if g.nodes()[n]['type']
+    return g.subgraph([n for n in g.nodes_iter() if n['type']
                        == 'Switch'])
 
 def relabel_switch_tree(g):

--- a/src/ibtopotool.py
+++ b/src/ibtopotool.py
@@ -173,7 +173,7 @@ def treeify(g, rootfile):
 
 def only_switches(g):
     """Filter out nodes that are not switches"""
-    return g.subgraph([n for n in g.nodes_iter() if n['type']
+    return g.subgraph([n for n in g if n['type']
                        == 'Switch'])
 
 def relabel_switch_tree(g):


### PR DESCRIPTION
G.node was dropped on v2.4: https://networkx.org/documentation/stable/release/release_2.4.html (deprecated in 2.1), it should be safe for networkx >= 2.0