### PR TITLE
Test topologies and tests

### DIFF
--- a/tests/1.topo
+++ b/tests/1.topo
@@ -1,0 +1,52 @@
+#
+# Topology file: generated on Tue Jun  5 14:15:10 2007
+#
+# Max of 3 hops discovered
+# Initiated from node 0008f10403960558 port 0008f10403960559
+
+Non-Chassis Nodes
+
+vendid=0x8f1
+devid=0x5a06
+sysimgguid=0x5442ba00003000
+switchguid=0x5442ba00003080(5442ba00003080)
+Switch  24 "S-005442ba00003080"         # "ISR9024 Voltaire" base port 0 lid 6 lmc 0
+[22]    "H-0008f10403961354"[1](8f10403961355)         # "MT23108 InfiniHost Mellanox Technologies" lid 4 4xSDR
+[10]    "S-0008f10400410015"[1]         # "SW-6IB4 Voltaire" lid 3 4xSDR
+[8]     "H-0008f10403960558"[2](8f1040396055a)         # "MT23108 InfiniHost Mellanox Technologies" lid 14 4xSDR
+[6]     "S-0008f10400410015"[3]         # "SW-6IB4 Voltaire" lid 3 4xSDR
+[12]    "H-0008f10403960558"[1](8f10403960559)         # "MT23108 InfiniHost Mellanox Technologies" lid 10 4xSDR
+
+vendid=0x8f1
+devid=0x5a05
+switchguid=0x8f10400410015(8f10400410015)
+Switch  8 "S-0008f10400410015"          # "SW-6IB4 Voltaire" base port 0 lid 3 lmc 0
+[6]     "H-0008f10403960984"[1](8f10403960985)         # "MT23108 InfiniHost Mellanox Technologies" lid 16 4xSDR
+[4]     "H-005442b100004900"[1](5442b100004901)        # "MT23108 InfiniHost Mellanox Technologies" lid 12 4xSDR
+[1]     "S-005442ba00003080"[10]                # "ISR9024 Voltaire" lid 6 1xSDR
+[3]     "S-005442ba00003080"[6]         # "ISR9024 Voltaire" lid 6 4xSDR
+
+vendid=0x2c9
+devid=0x5a44
+caguid=0x8f10403960984
+Ca      2 "H-0008f10403960984"          # "MT23108 InfiniHost Mellanox Technologies"
+[1](8f10403960985)     "S-0008f10400410015"[6]         # lid 16 lmc 1 "SW-6IB4 Voltaire" lid 3 4xSDR
+
+vendid=0x2c9
+devid=0x5a44
+caguid=0x5442b100004900
+Ca      2 "H-005442b100004900"          # "MT23108 InfiniHost Mellanox Technologies"
+[1](5442b100004901)     "S-0008f10400410015"[4]         # lid 12 lmc 1 "SW-6IB4 Voltaire" lid 3 4xSDR
+
+vendid=0x2c9
+devid=0x5a44
+caguid=0x8f10403961354
+Ca      2 "H-0008f10403961354"          # "MT23108 InfiniHost Mellanox Technologies"
+[1](8f10403961355)     "S-005442ba00003080"[22]                # lid 4 lmc 1 "ISR9024 Voltaire" lid 6 4xSDR
+
+vendid=0x2c9
+devid=0x5a44
+caguid=0x8f10403960558
+Ca      2 "H-0008f10403960558"          # "MT23108 InfiniHost Mellanox Technologies"
+[2](8f1040396055a)     "S-005442ba00003080"[8]         # lid 14 lmc 1 "ISR9024 Voltaire" lid 6 4xSDR
+[1](8f10403960559)     "S-005442ba00003080"[12]                # lid 10 lmc 1 "ISR9024 Voltaire" lid 6 1xSDR

--- a/tests/2.topo
+++ b/tests/2.topo
@@ -1,0 +1,26 @@
+#
+# Topology file: generated on Wed May  6 15:14:42 2009
+#
+# Max of 2 hops discovered
+# Initiated from node 0002c9030002847c port 0002c9030002847e
+
+vendid=0x2c9
+devid=0xa87c
+switchguid=0xb8cffff0053ee(b8cffff0053ee)
+Switch  8 "S-000b8cffff0053ee"          # "MT43132 Mellanox Technologies" base port 0 lid 3 lmc 0
+[1]     "H-0002c902002789ac"[1](2c902002789ad)          # "compute-00-01 HCA-1" lid 1 4xSDR
+[2]     "H-0002c9030002847c"[2](2c9030002847e)          # "compute-00-00 HCA-1" lid 2 4xSDR
+
+vendid=0x2c9
+devid=0x5a44
+sysimgguid=0x2c902002789af
+caguid=0x2c902002789ac
+Ca      2 "H-0002c902002789ac"          # "compute-00-01 HCA-1"
+[1](2c902002789ad)      "S-000b8cffff0053ee"[1]         # lid 1 lmc 0 "MT43132 Mellanox Technologies" lid 3 4xSDR
+
+vendid=0x2c9
+devid=0x6340
+sysimgguid=0x2c9030002847f
+caguid=0x2c9030002847c
+Ca      2 "H-0002c9030002847c"          # "compute-00-00 HCA-1"
+[2](2c9030002847e)      "S-000b8cffff0053ee"[2]         # lid 2 lmc 0 "MT43132 Mellanox Technologies" lid 3 4xSDR

--- a/tests/3.topo
+++ b/tests/3.topo
@@ -1,0 +1,73 @@
+src/query_smp.c:195; umad (DR path slid 0; dlid 0; 0,1,1,31 Attr 0x11:0) bad status 110; Connection timed out
+#
+# Topology file: generated on Mon Jul 25 11:30:26 2016
+#
+# Initiated from node 0002c9030004e938 port 0002c9030004e939
+
+vendid=0x2c9
+devid=0xcb20
+sysimgguid=0xe41d2d030003e470
+switchguid=0xe41d2d030003e470(e41d2d030003e470)
+Switch 36 "S-e41d2d030003e470" # "SwitchIB Mellanox Technologies" base port 0 lid 268 lmc 0
+[1] "S-e41d2d030003e470"[2] # "SwitchIB Mellanox Technologies" lid 268 4xEDR
+[2] "S-e41d2d030003e470"[1] # "SwitchIB Mellanox Technologies" lid 268 4xEDR
+[3] "S-f4521403005764b0"[1] # "MF0;switch-de779e:SX6012/U1" lid 174 4xFDR
+[19] "S-e41d2d030003e470"[21] # "SwitchIB Mellanox Technologies" lid 268 4xEDR
+[21] "S-e41d2d030003e470"[19] # "SwitchIB Mellanox Technologies" lid 268 4xEDR
+[29] "S-e41d2d030003e470"[30] # "SwitchIB Mellanox Technologies" lid 268 4xEDR
+[30] "S-e41d2d030003e470"[29] # "SwitchIB Mellanox Technologies" lid 268 4xEDR
+[34] "H-e41d2d030061f957"[1](e41d2d030061f957) # "r-ufm216 HCA-2" lid 2 4xEDR
+[35] "H-0002c903003421b0"[2](2c903003421b2) # "r-ufm111 HCA-1" lid 3 4xFDR
+
+vendid=0x2c9
+devid=0xc738
+sysimgguid=0xf4521403005764b0
+switchguid=0xf4521403005764b0(f4521403005764b0)
+Switch 12 "S-f4521403005764b0" # "MF0;switch-de779e:SX6012/U1" enhanced port 0 lid 174 lmc 0
+[1] "S-e41d2d030003e470"[3] # "SwitchIB Mellanox Technologies" lid 268 4xFDR
+[2] "H-0002c9030004e938"[1](2c9030004e939) # "r-ufm101 HCA-1" lid 27 4xQDR
+[3] "H-0002c9030006ba5a"[1](2c9030006ba5b) # "r-ufm101 HCA-2" lid 30 4xQDR
+[6] "H-0002c90300337140"[1](2c90300337141) # "r-ufm100 HCA-2" lid 28 4xFDR
+[8] "H-e41d2d03005cf1f8"[1](e41d2d03005cf1f8) # "r-ufm96 HCA-1" lid 1 4xSDR
+
+vendid=0x2c9
+devid=0x1003
+sysimgguid=0x2c903003421b3
+caguid=0x2c903003421b0
+Ca 2 "H-0002c903003421b0" # "r-ufm111 HCA-1"
+[2](2c903003421b2) "S-e41d2d030003e470"[35] # lid 3 lmc 0 "SwitchIB Mellanox Technologies" lid 268 4xFDR
+
+vendid=0x2c9
+devid=0x1013
+sysimgguid=0xe41d2d030061f956
+caguid=0xe41d2d030061f957
+Ca 1 "H-e41d2d030061f957" # "r-ufm216 HCA-2"
+[1](e41d2d030061f957) "S-e41d2d030003e470"[34] # lid 2 lmc 0 "SwitchIB Mellanox Technologies" lid 268 4xEDR
+
+vendid=0x2c9
+devid=0x673c
+sysimgguid=0x2c9030006ba5d
+caguid=0x2c9030006ba5a
+Ca 2 "H-0002c9030006ba5a" # "r-ufm101 HCA-2"
+[1](2c9030006ba5b) "S-f4521403005764b0"[3] # lid 30 lmc 0 "MF0;switch-de779e:SX6012/U1" lid 174 4xQDR
+
+vendid=0x2c9
+devid=0x1003
+sysimgguid=0x2c90300337143
+caguid=0x2c90300337140
+Ca 2 "H-0002c90300337140" # "r-ufm100 HCA-2"
+[1](2c90300337141) "S-f4521403005764b0"[6] # lid 28 lmc 0 "MF0;switch-de779e:SX6012/U1" lid 174 4xFDR
+
+vendid=0x2c9
+devid=0x1013
+sysimgguid=0xe41d2d03005cf1f8
+caguid=0xe41d2d03005cf1f8
+Ca 1 "H-e41d2d03005cf1f8" # "r-ufm96 HCA-1"
+[1](e41d2d03005cf1f8) "S-f4521403005764b0"[8] # lid 1 lmc 0 "MF0;switch-de779e:SX6012/U1" lid 174 4xSDR
+
+vendid=0x2c9
+devid=0x673c
+sysimgguid=0x2c9030004e93b
+caguid=0x2c9030004e938
+Ca 1 "H-0002c9030004e938" # "r-ufm101 HCA-1"
+[1](2c9030004e939) "S-f4521403005764b0"[2] # lid 27 lmc 0 "MF0;switch-de779e:SX6012/U1" lid 174 4xQDR

--- a/tests/4.topo
+++ b/tests/4.topo
@@ -1,0 +1,18 @@
+#
+# Topology file: generated on Sat Apr 13 22:28:55 2002
+#
+# Max of 1 hops discovered
+# Initiated from node 0021283a8389a0a0 port 0021283a8389a0a0
+vendid=0x2c9
+devid=0xbd36
+sysimgguid=0x21283a8389a0a3
+switchguid=0x21283a8389a0a0(21283a8389a0a0)
+Switch  36 "S-0021283a8389a0a0" # "Sun DCS 36 QDR switch localhost" enhanced port 0 lid 15 lmc 0
+[23]    "H-0003ba000100e388"[2](3ba000100e38a) # "nsn33-43 HCA-1" lid 14 4xQDR
+ 
+vendid=0x2c9
+devid=0x673c
+sysimgguid=0x3ba000100e38b
+caguid=0x3ba000100e388
+Ca      2 "H-0003ba000100e388" # "nsn33-43 HCA-1"
+[2](3ba000100e38a)      "S-0021283a8389a0a0"[23] # lid 14 lmc 0 "Sun DCS 36 QDR switch localhost" lid 15 4xQDR

--- a/tests/notes.rst
+++ b/tests/notes.rst
@@ -1,0 +1,19 @@
+==========
+Test notes
+==========
+
+
+How to run
+==========
+
+``cd tests``
+``./run_tests.sh``
+
+
+Test topology sources
+=====================
+
+* 1.topo: ``man ibnetdiscover``
+* 2.topo: https://www.ibm.com/support/pages/troubleshooting-infiniband-network-issues-platform-cluster-manager
+* 3.topo: https://enterprise-support.nvidia.com/s/article/howto-find-the-path-between-two-lids-in-infiniband-network-using-ibdiagpath
+* 4.topo: https://docs.oracle.com/cd/E19197-01/835-0784-05/z400014e1393438.html

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+for TOPO in *.topo; do
+
+  # For now, use a bulk extension ".out" for all output cases
+  OUTFILE=${TOPO%.*topo}.out
+
+  # Assign the first found switch as a single treeify root
+  grep -E '^Switch' ${TOPO} | head -1 | awk '{print $3}' | sed 's/"//g' > t.tmp
+
+  CMD_ARRAY=(
+    "python3 ../src/ibtopotool.py                           -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py -s                        -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py -t t.tmp                  -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py -s -t t.tmp               -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py -s --shortlabels          -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py -t t.tmp --shortlabels    -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py -s -t t.tmp --shortlabels -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py --slurm                   -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py --slurm -t t.tmp          -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py --slurm -s                -o ${OUTFILE} ${TOPO}"
+    "python3 ../src/ibtopotool.py --slurm -s -t t.tmp       -o ${OUTFILE} ${TOPO}"
+  )
+
+  # Execute tests
+  for (( i = 0; i < ${#CMD_ARRAY[@]}; i++ ))
+  do
+    CMD="${CMD_ARRAY[$i]}"
+    ${CMD}
+    CMD_RESULT="((1-$?))"
+    (( ${CMD_RESULT} )) && echo "Success: ${CMD}"
+    (( ${CMD_RESULT} )) || echo "Failure: ${CMD}"
+  done
+
+  # Cleanup
+  if stat *.out 1>/dev/null 2>/dev/null; then rm *.out; fi
+  if stat t.tmp 1>/dev/null 2>/dev/null; then rm t.tmp; fi
+
+done


### PR DESCRIPTION
Most imporantly add the topology from the manpage of `ibnetdiscover`.

Also include topologies found from various public sources, and a test script for validating the topologies.

Please note, all tests do not pass currently. A separate PR #6 created for possible fixes.