### PR TITLE
Graph processing fixes

### DIFF
--- a/src/ibtopotool.py
+++ b/src/ibtopotool.py
@@ -168,12 +168,13 @@ def treeify(g, rootfile):
         for nbr in nbrs:
             if g.nodes[n]['rank'] > g.nodes[nbr]['rank']:
                 todel.append((n, nbr))
-    g.remove_edges_from(todel)
-    return g
+    g2 = nx.Graph(g)
+    g2.remove_edges_from(todel)
+    return g2
 
 def only_switches(g):
     """Filter out nodes that are not switches"""
-    return g.subgraph([n for n in g if n['type']
+    return g.subgraph([n for n in g.nodes() if g.nodes()[n]['type']
                        == 'Switch'])
 
 def relabel_switch_tree(g):


### PR DESCRIPTION
Encountered two errors with:

- Python 3.10.12
- networkx==3.4.2
- python-hostlist==2.2.1
- pydot==3.0.3

First error:

```
  File "/somepath/ibtopotool.py", line 176, in <listcomp>
    return g.subgraph([n for n in g if n['type']
TypeError: string indices must be integers
```

The syntax from PR #2 commit 2ee32f94 seems to work better with these particular test topologies and library versions. Proposing to revert back to the syntax from that quickfix commit.

Second error:

```
  File "/somepath/src/ibtopotool.py", line 171, in treeify
    g.remove_edges_from(todel)
  File "/somelibpath/python3.10/site-packages/networkx/classes/function.py", line 170, in frozen
    raise nx.NetworkXError("Frozen graph can't be modified")
networkx.exception.NetworkXError: Frozen graph can't be modified
```

This is strange since it seems to manifest with `networkx==2.4` as well. In any case the documentation recommends making a copy:

https://networkx.org/documentation/stable/reference/generated/networkx.classes.function.freeze.html

...so proposing to do that.