### PR TITLE
Improve spine topologies

### DIFF
--- a/src/ibtopotool.py
+++ b/src/ibtopotool.py
@@ -106,7 +106,7 @@ def gen_mermaid(g, out):
     """
     if options.markdown:
         out.write('```mermaid\n')
-    out.write('graph TD\n')
+    out.write('graph LR\n')
     ##In case some particular topology would render more cleanly on elk:
     #out.write('%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%\n')
     for n, nbrs in g.adjacency():
@@ -116,7 +116,7 @@ def gen_mermaid(g, out):
             if g.nodes[nbr]['type'] == 'Switch':
                 switches.append('%s(%s)' % (nbr, g.nodes[nbr]['label']))
             else:
-                nodes.append('%s(%s)' % (nbr, g.nodes[nbr]['label']))
+                nodes.append('%s' % (g.nodes[nbr]['label']))
         if len(switches) > 0:
             for sw in switches:
                 out.write('%s(%s) --> %s\n' % (n, g.nodes[n]['label'], sw))
@@ -197,7 +197,7 @@ def treeify(g, rootfile):
         for nbr in nbrs:
             if g.nodes[n]['rank'] > g.nodes[nbr]['rank']:
                 todel.append((n, nbr))
-    g2 = nx.Graph(g)
+    g2 = nx.DiGraph(g)
     g2.remove_edges_from(todel)
     return g2
 


### PR DESCRIPTION
Been working with more elaborate Quantum topologies recently and as part of this realized previous fix was lacking. It did render without errors, but edges end up missing.

Changes:

- Spawn a DiGraph instead of Graph when getting ready to prune the copy of a treeified graph. If previously we couldn't do a g.remove_edges_from(todel) since g had changed to be immutable via NetworkX changes, the compensating copy should use DiGraph() since the parser is also using DiGraph().

- Change mermaid orientation to be left-to-right by default.

- Change mermaid to use labels instead of discovered raw HCA names, this saves some screen real-estate when rendering huge topologies.